### PR TITLE
fix: resolve compiler warnings and improve error handling

### DIFF
--- a/src/biblatex/biblatex.mbti
+++ b/src/biblatex/biblatex.mbti
@@ -3,6 +3,8 @@ package "Lampese/biblatex/biblatex"
 
 // Values
 
+// Errors
+
 // Types and methods
 pub struct Bibliography {
   // private fields
@@ -38,7 +40,7 @@ fn Entry::isbn(Self) -> String?
 fn Entry::issn(Self) -> String?
 fn Entry::journal(Self) -> String?
 fn Entry::month(Self) -> String?
-fn Entry::new(entry_type~ : String, cite_key~ : String, fields~ : Map[String, Value] = ..) -> Self
+fn Entry::new(entry_type~ : String, cite_key~ : String, fields? : Map[String, Value]) -> Self
 fn Entry::note(Self) -> String?
 fn Entry::number(Self) -> Value?
 fn Entry::organization(Self) -> String?

--- a/src/biblatex/entry.mbt
+++ b/src/biblatex/entry.mbt
@@ -560,10 +560,9 @@ pub fn Entry::set_issn(self : Entry, issn : String) -> Unit {
 /// Get the journal of the Entry.
 /// ```mbt
 /// let entry = Entry::new(entry_type="article", cite_key="CitekeyArticle", fields={
-///   "journal":String("The independence of the continuum hypothesis"),
 ///   "journal":String("Proceedings of the National Academy of Sciences"),
 /// })
-/// entry.journal() |> ignore() // Some("The independence of the continuum hypothesis")
+/// entry.journal() |> ignore() // Some("Proceedings of the National Academy of Sciences")
 /// ```
 pub fn Entry::journal(self : Entry) -> String? {
   match self.fields.get("journal") {
@@ -576,7 +575,6 @@ pub fn Entry::journal(self : Entry) -> String? {
 /// Set the journal of the Entry.
 /// ```mbt
 /// let entry = Entry::new(entry_type="article", cite_key="CitekeyArticle", fields={
-///   "journal":String("The independence of the continuum hypothesis"),
 ///   "journal":String("Proceedings of the National Academy of Sciences"),
 /// })
 /// entry.set_journal("The independence of the continuum hypothesis2")
@@ -786,6 +784,7 @@ pub fn Entry::school(self : Entry) -> String? {
 /// })
 /// entry.set_school("The independence of the continuum hypothesis2")
 /// entry.school() |> ignore() // Some("The independence of the continuum hypothesis2")
+/// ```
 pub fn Entry::set_school(self : Entry, school : String) -> Unit {
   self.fields.set("school", Value::String(school))
 }
@@ -858,6 +857,7 @@ pub fn Entry::set_series(self : Entry, series : String) -> Unit {
 ///   "journal":String("Proceedings of the National Academy of Sciences"),
 /// })
 /// entry.url() |> ignore() // Some("\\url{https://www.google.com}")
+/// ```
 pub fn Entry::url(self : Entry) -> String? {
   match self.fields.get("url") {
     Some(Value::String(url)) => Some(url)
@@ -873,7 +873,7 @@ pub fn Entry::url(self : Entry) -> String? {
 ///   "journal":String("Proceedings of the National Academy of Sciences"),
 /// })
 /// entry.set_url("\\url{https://www.google.com}")
-/// entry.url() |> ignore() // Some("\url{https://www.google.com}")
+/// entry.url() |> ignore() // Some("\\url{https://www.google.com}")
 /// ```
 pub fn Entry::set_url(self : Entry, url : String) -> Unit {
   self.fields.set("url", Value::String(url))

--- a/src/biblatex/lexer.mbt
+++ b/src/biblatex/lexer.mbt
@@ -23,13 +23,14 @@ priv struct Lexer {
 
 ///|
 fn Lexer::new(input : String) -> Lexer {
-  { input, currentChar: Some(input.get_char(0).unwrap()), currentIndex: 1 }
+  let current_char = if input.length() > 0 { input.get_char(0) } else { None }
+  { input, currentChar: current_char, currentIndex: 1 }
 }
 
 ///|
 fn Lexer::advance(self : Lexer) -> Unit {
   if self.currentIndex < self.input.length() {
-    self.currentChar = Some(self.input.get_char(self.currentIndex).unwrap())
+    self.currentChar = self.input.get_char(self.currentIndex)
     self.currentIndex += 1
   } else {
     self.currentChar = None
@@ -39,7 +40,7 @@ fn Lexer::advance(self : Lexer) -> Unit {
 ///|
 fn Lexer::back(self : Lexer) -> Unit {
   self.currentIndex -= 1
-  self.currentChar = Some(self.input.get_char(self.currentIndex).unwrap())
+  self.currentChar = self.input.get_char(self.currentIndex)
 }
 
 ///|
@@ -97,7 +98,10 @@ fn Lexer::escape_handle(
           buffer.write_string(Lexer::escape_handle(self, start_char, false))
           self.advance() // notice that
         } else {
-          buffer.write_char(self.currentChar.unwrap())
+          match self.currentChar {
+            Some(ch) => buffer.write_char(ch)
+            None => () // should not happen due to loop condition
+          }
         }
         self.advance()
       }

--- a/src/biblatex/transform.mbt
+++ b/src/biblatex/transform.mbt
@@ -5,11 +5,12 @@ fn to_value(value : InnerValue, string_map : Map[String, InnerValue]) -> Value {
     Digit(value) => Value::Digit(value)
     Month(value) => Value::Month(value)
     ToValue(value) =>
-      match string_map.get(value).unwrap() {
-        String(value) => Value::String(value)
-        Digit(value) => Value::Digit(value)
-        Month(value) => Value::Month(value)
-        ToValue(value) => to_value(ToValue(value), string_map)
+      match string_map.get(value) {
+        Some(String(value)) => Value::String(value)
+        Some(Digit(value)) => Value::Digit(value)
+        Some(Month(value)) => Value::Month(value)
+        Some(ToValue(value)) => to_value(ToValue(value), string_map)
+        None => Value::String(value) // fallback to original value if not found in string map
       }
   }
 }

--- a/src/test/test.mbti
+++ b/src/test/test.mbti
@@ -3,6 +3,8 @@ package "Lampese/biblatex/test"
 
 // Values
 
+// Errors
+
 // Types and methods
 
 // Type aliases


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Fix missing closing comment markers in documentation
- Fix duplicate field assignments in documentation examples
- Improve error handling by replacing unwrap() calls with proper pattern matching
- Add empty string handling in Lexer::new function
- Fix inconsistent backslash handling in URL documentation
- Remove unnecessary unwrap calls for safer code

These changes resolve potential compiler warnings and improve code reliability
by handling edge cases more gracefully.